### PR TITLE
Use current.geneontology.org as xref source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,8 @@
       "name": "@geneontology/dbxrefs",
       "version": "1.1.0",
       "license": "MIT",
-      "dependencies": {
-        "yaml": "^2.8.0"
-      },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.15.29",
         "del-cli": "^6.0.0",
         "eslint": "^9.28.0",
@@ -736,13 +732,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2370,18 +2359,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -28,17 +28,14 @@
   },
   "scripts": {
     "clean": "del-cli dist",
-    "build": "npm run clean && tsc",
+    "prebuild": "npm run clean",
+    "build": "tsc",
     "format": "prettier --write .",
     "lint": "eslint .",
     "test": "tsx --test"
   },
-  "dependencies": {
-    "yaml": "^2.8.0"
-  },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.15.29",
     "del-cli": "^6.0.0",
     "eslint": "^9.28.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,4 @@
-import { parse } from "yaml";
-
-const DB_XREFS_URL =
-  "https://raw.githubusercontent.com/geneontology/go-site/master/metadata/db-xrefs.yaml";
+const DB_XREFS_URL = "https://current.geneontology.org/metadata/db-xrefs.json";
 
 // Derived from https://github.com/geneontology/go-site/blob/d911c0ad30dbb2ec333e9d0f63804c8797ed79c2/metadata/db-xrefs.schema.yaml
 interface EntityType {
@@ -97,8 +94,7 @@ async function init() {
         `Failed to fetch dbxrefs: ${response.status} ${response.statusText}`,
       );
     }
-    const body = await response.text();
-    dbxrefs = parse(body) as DBXref[];
+    dbxrefs = (await response.json()) as DBXref[];
     dbReady = true;
     dbError = false;
     return dbxrefs;

--- a/test/main.ts
+++ b/test/main.ts
@@ -5,23 +5,30 @@ import * as dbxrefs from "../src/main.js";
 
 before(() => {
   mock.method(global, "fetch", async (url: string) => {
-    if (
-      url ===
-      "https://raw.githubusercontent.com/geneontology/go-site/master/metadata/db-xrefs.yaml"
-    ) {
-      return new Response(
-        `
-- database: testdb
-  synonyms:
-    - testdbsyn
-  entity_types:
-    - type_name: gene
-      url_syntax: https://example.com/gene/[example_id]
-    - type_name: protein
-      url_syntax: https://example.com/protein/[example_id]
-    - type_name: no_url_syntax`,
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+    if (url === "https://current.geneontology.org/metadata/db-xrefs.json") {
+      const body = [
+        {
+          database: "testdb",
+          synonyms: ["testdbsyn"],
+          entity_types: [
+            {
+              type_name: "gene",
+              url_syntax: "https://example.com/gene/[example_id]",
+            },
+            {
+              type_name: "protein",
+              url_syntax: "https://example.com/protein/[example_id]",
+            },
+            {
+              type_name: "no_url_syntax",
+            },
+          ],
+        },
+      ];
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
     }
     throw new Error("Unexpected URL: " + url);
   });


### PR DESCRIPTION
Fixes #1 

These changes replace a GitHub URL with `current.geneontology.org` as the source of xrefs. Since the file on `current.geneontology.org` is a JSON file (as opposed to the YAML file on GitHub), the dependency the `yaml` package could also be removed.